### PR TITLE
Modify `x-forwarded-for-bypass` template to include variety of Headers

### DIFF
--- a/packages/backend/src/defaultTemplates/add-headers.yaml
+++ b/packages/backend/src/defaultTemplates/add-headers.yaml
@@ -1,0 +1,26 @@
+id: add-headers
+description: "Adds multiple headers for bypassing 403"
+enabled: true
+modificationScript: |-
+  const headersToAdd = [
+    "X-Forwarded-Port: 80",
+    "X-Forwarded-By: 127.0.0.1",
+    "X-Forwarded-For: 127.0.0.1",
+    "X-Forwarded-Host: 127.0.0.1",
+    "Referer: 127.0.0.1",
+    "Redirect: 127.0.0.1",
+    "Client-IP: 127.0.0.1",
+    "X-Real-Ip: 127.0.0.1",
+    "X-True-IP: 127.0.0.1"
+    "X-Client-IP: 127.0.0.1",
+    "X-Custom-IP-Authorization: 127.0.0.1",
+  ];
+
+  for (const header of headersToAdd) {
+    const [headerKey] = header.split(":");
+    if (!helper.hasHeader(input, headerKey.trim())) {
+      input = helper.addHeader(input, header);
+    }
+  }
+
+  return input;

--- a/packages/backend/src/defaultTemplates/x-forwarded-for-bypass.yaml
+++ b/packages/backend/src/defaultTemplates/x-forwarded-for-bypass.yaml
@@ -1,6 +1,0 @@
-id: x-forwarded-for-bypass
-description: "Adds X-Forwarded-For: 0.0.0.0 header"
-enabled: true
-modificationScript: |-
-  input = helper.addHeader(input, "X-Forwarded-For: 0.0.0.0")
-  return input;


### PR DESCRIPTION
Renamed and enhanced the `x-forwarded-for-bypass.yaml` template. Now it contains multiple headers for 403 bypass.
Headers are only added if not already present.