### PR TITLE
Fix #12 Template Import Failing

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,3 +1,5 @@
+import "./polyfills";
+
 import { type DefineAPI, type SDK } from "caido:plugin";
 
 import {

--- a/packages/backend/src/polyfills.ts
+++ b/packages/backend/src/polyfills.ts
@@ -1,0 +1,5 @@
+declare const process: unknown;
+
+if (typeof process === "undefined") {
+  (globalThis as unknown as Record<string, unknown>).process = { env: {} };
+}


### PR DESCRIPTION
This PR Fixes #12 

## Root Cause

The `yaml` npm package (v2.6.1) ships two builds: a **Node build** (`dist/`) and a **Browser build** (`browser/`). The Node build contains unguarded `process.env` references in its parser and composer:

```js
// yaml/dist/parse/parser.js - called on every token during YAML.parse()
*next(source) {
  if (process.env.LOG_TOKENS)   // no typeof guard - throws ReferenceError
    console.log("|", cst.prettyToken(source));
}

// yaml/dist/compose/composer.js - called on every token during YAML.parse()
*next(token) {
  if (process.env.LOG_STREAM)   // no typeof guard - throws ReferenceError
    console.dir(token, { depth: null });
}
```

The backend is bundled by **tsup** (via `@caido-community/dev`) which resolves the `"node"` export condition, pulling in the Node build. Since Caido's plugin runtime is a sandboxed environment **without a `process` global**, any call to `YAML.parse()` immediately throws `ReferenceError: process is not defined`.

The build config cannot be customized because `@caido-community/dev` generates tsup config internally with `config: false` (ignores local overrides) and the backend plugin schema does not accept `define` or `resolve` options.

## Fix

A minimal `process` polyfill in `packages/backend/src/polyfills.ts`, imported as the very first line of `packages/backend/src/index.ts`